### PR TITLE
Fix single-package lookup bug

### DIFF
--- a/conda.rb
+++ b/conda.rb
@@ -43,7 +43,7 @@ class Conda
   end
 
   def package(channel, name)
-    packs = packages(channel)
+    packs = packages_by_channel(channel)
     raise Sinatra::NotFound unless packs.key?(name)
 
     packs[name]


### PR DESCRIPTION
Looks like this method got renamed but one of the call-sites wasn't updated. Fixes:

![Screen Shot 2021-02-24 at 10 55 14 AM](https://user-images.githubusercontent.com/5054/109027644-0323a280-768f-11eb-9624-5cc7fef00594.png)
