### PR TITLE
conda-forge isn't setting content-type headers correctly in all cases

### DIFF
--- a/channel.rb
+++ b/channel.rb
@@ -59,6 +59,8 @@ class Channel
 
           packages[package_name][:versions] << release_version(key, version)
         end
+      rescue => e
+        puts "Failed to fetch for #{arch} https://#{@domain}/#{@channel_name}/#{arch}/repodata.json"
       end
     end
     puts "Finished in #{benchmark.real.round(1)} sec: #{packages.to_json.bytesize / 1_000_000}mb of data."


### PR DESCRIPTION
conda-forge is returning binary/octet-stream instead of application/json
for repodata when there aren't any packages which is then making this
explode. Handle just by failing gracefully
